### PR TITLE
Don't use `git.depth=1` anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ cache:
   - $HOME/.ghc-build
   - $HOME/.ghc-tools
 env: CABALVER=1.18 GHCVER=7.8.4
-git:
-  depth: 1
 install:
 - export PATH=$HOME/.cabal/bin:$PATH
 - export PATH=$HOME/.cabal-build/bin:$PATH

--- a/templates/base.yml
+++ b/templates/base.yml
@@ -9,12 +9,6 @@ branches:
   only:
     - master
 
-# Only clone a single revision by default. This has the desirable result that
-# adding commits while a previous commit is in the Travis queue will make Travis
-# not build the previously queued build.
-git:
-  depth: 1
-
 # Add elements to the special __erase__ field to remove sections that are only
 # used during generation and have no meaning to Travis.
 __erase__:


### PR DESCRIPTION
This was a bad idea. It prevents us from restarting past builds, because
Travis will always only check out master, not actually the ref that was
built.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/github-tools/54)
<!-- Reviewable:end -->
