### PR TITLE
Fix roadmap milestone ordering.

### DIFF
--- a/src/Changelogs.hs
+++ b/src/Changelogs.hs
@@ -118,10 +118,11 @@ makeChangeLog wantRoadmap ownerName repoName pulls issues =
   . groupByMilestone (second . (:)) changeLogPrs
   $ Map.empty
   where
-    sortChangelog [] = []
-    sortChangelog l@(backlog:rest) =
+    sortChangelog l =
       if wantRoadmap
-        then backlog : reverse rest
+        then case reverse l of
+          []   -> []
+          x:xs -> xs ++ [x] -- Put "Backlog" last.
         else l
 
     (mergedPrs, openPrs) = List.partition (\case


### PR DESCRIPTION
It used to bring v0.3.0 to the front, before Backlog and all others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/github-tools/72)
<!-- Reviewable:end -->
