### PR TITLE
Add travis_wait before cabal test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,5 @@ script:
 - cabal install --enable-tests --enable-benchmarks --only-dependencies ./
 - if [ -n "" ]; then cabal install ; fi
 - cabal configure --enable-tests --enable-benchmarks --enable-library-coverage
-- cabal test
+- travis_wait cabal test
 - cabal check

--- a/templates/haskell.yml
+++ b/templates/haskell.yml
@@ -102,7 +102,7 @@ script:
     - if [ -n "%haskell.packages%" ]; then cabal install %haskell.packages%; fi
     # Now to the actual build.
     - cabal configure --enable-tests --enable-benchmarks --enable-library-coverage
-    - cabal test
+    - travis_wait cabal test
     - cabal check
 
 after_script:


### PR DESCRIPTION
To avoid timeouts of long-running tests.